### PR TITLE
Add cases for testing the new DisableDNS property

### DIFF
--- a/helm-disable-dns/not-set/chart/Chart.yaml
+++ b/helm-disable-dns/not-set/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dns-test
+description: A Helm chart to verify fleet's DisableDNS functionality
+version: "0.0.1"
+appVersion: "0.0.1"

--- a/helm-disable-dns/not-set/chart/templates/configmap.yaml
+++ b/helm-disable-dns/not-set/chart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hosts-config
+data:
+  host: {{ .Values.host | getHostByName | required "DNS is not enabled" }}

--- a/helm-disable-dns/not-set/chart/values.yaml
+++ b/helm-disable-dns/not-set/chart/values.yaml
@@ -1,0 +1,1 @@
+host: github.com

--- a/helm-disable-dns/not-set/fleet.yaml
+++ b/helm-disable-dns/not-set/fleet.yaml
@@ -1,0 +1,2 @@
+helm:
+  chart: chart

--- a/helm-disable-dns/set/chart/Chart.yaml
+++ b/helm-disable-dns/set/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dns-test
+description: A Helm chart to verify fleet's DisableDNS functionality
+version: "0.0.1"
+appVersion: "0.0.1"

--- a/helm-disable-dns/set/chart/templates/configmap.yaml
+++ b/helm-disable-dns/set/chart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hosts-config
+data:
+  host: {{ .Values.host | getHostByName | required "DNS is not enabled" }}

--- a/helm-disable-dns/set/chart/values.yaml
+++ b/helm-disable-dns/set/chart/values.yaml
@@ -1,0 +1,1 @@
+host: github.com

--- a/helm-disable-dns/set/fleet.yaml
+++ b/helm-disable-dns/set/fleet.yaml
@@ -1,0 +1,3 @@
+helm:
+  chart: chart
+  disableDNS: true


### PR DESCRIPTION
Will be used as part of rancher/fleet#1755.

I tried adding the chart at `helm-disable-dns` level and both using a relative path (like `chart: ../chart`) in each `fleet.yaml` and using symlinks, but it didn't work, so I ended up duplicating the chart.