### PR TITLE
Use configmap chart for `helm-oci` tests

### DIFF
--- a/helm-oci/fleet.yaml
+++ b/helm-oci/fleet.yaml
@@ -12,7 +12,7 @@ helm:
   # The directory of the chart in the repo.  Also any valid go-getter supported
   # URL can be used there is specify where to download the chart from.
   # If repo below is set this value if the chart name in the repo
-  chart: "oci://ghcr.io/fleetrepoci/sleeper-chart"
+  chart: "oci://ghcr.io/rancher/fleet-test-configmap-chart"
 
   # An https to a valid Helm repository to download the chart from
   repo: ""


### PR DESCRIPTION
This chart contains only a configmap, making it even more lightweight than a sleeper chart which spawns a pod.

This is a follow-up on #6, tested via [fleet#1876](https://github.com/rancher/fleet/pull/1876).