### PR TITLE
Use configmap-only test chart for Helm OCI tests

### DIFF
--- a/helm-oci-with-auth/fleet.yaml
+++ b/helm-oci-with-auth/fleet.yaml
@@ -2,17 +2,17 @@
 
 # The namespace this chart will be installed and restricted to,
 # if not specified the chart will be installed to "default"
-namespace: fleet-helm-oci-example
+namespace: fleet-helm-oci-with-auth-example
 
 # Custom helm options
 helm:
   # The release name to use. If empty a generated release name will be used
-  releaseName: fleet-test-configmap
+  releaseName: fleet-test-configmap-private
 
   # The directory of the chart in the repo.  Also any valid go-getter supported
   # URL can be used there is specify where to download the chart from.
   # If repo below is set this value if the chart name in the repo
-  chart: "oci://ghcr.io/rancher/fleet-test-configmap-chart"
+  chart: "oci://ghcr.io/fleetrepoci/fleet-test-configmap-chart-private"
 
   # An https to a valid Helm repository to download the chart from
   repo: ""


### PR DESCRIPTION
This restores path `helm-oci-with-auth`, deleted by mistake but used by Fleet's end-to-end tests requiring external secrets. Instead of using a private version of a `guestbook` chart, including a front-end server and a Redis instance, this now makes use of a much more lightweight, private test chart containing only a config map.

See [this run](https://github.com/rancher/fleet/actions/runs/6615722838) using changes from this branch.