### PR TITLE
Change values in fleet.yaml to make it the test purpose more explicit

### DIFF
--- a/helm-cluster-values/fleet.yaml
+++ b/helm-cluster-values/fleet.yaml
@@ -22,4 +22,7 @@ helm:
     annotations:
       app: fleet
       more: data
-    replicaCount: ${ randNumeric 0 }
+      # to test the ability to use functions
+      randomNumber: ${ randNumeric 3 | quote }
+    # to test explicit null values
+    replicaCount: ~


### PR DESCRIPTION
It was totally not obvious why the test expected replicas to be 1.
The previous setup depended on multiple caveats for reaching that, e.g. `randNumeric 0` returning `""`, but when used in the yaml template it would render as blank, which is interpreted as `null`. This `replicaCount: null` is what causes Helm to omit `replicaCount` from the original `values.yaml`, ending up no setting `replicas:` either, which defaults to 1.