### PR TITLE
Add nginx-app in fleet-test-data for QA automation

### DIFF
--- a/qa-test-apps/nginx-app/README.md
+++ b/qa-test-apps/nginx-app/README.md
@@ -1,9 +1,10 @@
-# In this example, we are using fleet option keepResources: true/false.
+# In this example, we are using the Fleet option keepResources: true/false.
 # This option will ensure that deployed application will not be deleted
-# after deleting GitRepo.
+# after deleting a GitRepo.
 
 This example will deploy the `nginx` application with 1 replica.
-The app will be deployed into the `nginx-keep` namespace.
+The app will be deployed to all available clusters in the `nginx-keep` namespace.
+See [Target Matching](https://fleet.rancher.io/gitrepo-targets#target-matching)
 
 ```yaml
 kind: GitRepo
@@ -18,11 +19,6 @@ spec:
   targetNamespace: keep-resources
   keepResources: true
   targets:
-    - clusterSelector:
-        matchExpressions:
-          - key: provider.cattle.io
-            operator: NotIn
-            values:
-              - harvester
+    - clusterSelector: {}
 ```
 

--- a/qa-test-apps/nginx-app/README.md
+++ b/qa-test-apps/nginx-app/README.md
@@ -1,0 +1,28 @@
+# In this example, we are using fleet option keepResources: true/false.
+# This option will ensure that deployed application will not be deleted
+# after deleting GitRepo.
+
+This example will deploy the `nginx` application with 1 replica.
+The app will be deployed into the `nginx-keep` namespace.
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: keep-resources
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/nginx-app
+  targetNamespace: keep-resources
+  keepResources: true
+  targets:
+    - clusterSelector:
+        matchExpressions:
+          - key: provider.cattle.io
+            operator: NotIn
+            values:
+              - harvester
+```
+

--- a/qa-test-apps/nginx-app/fleet.yaml
+++ b/qa-test-apps/nginx-app/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: nginx-keep

--- a/qa-test-apps/nginx-app/nginx.yaml
+++ b/qa-test-apps/nginx-app/nginx.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-keep
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
We are using fleet-test-data repository in automation, so we require few application to be present here. Now starting with Nginx. As we grow with automation will add more applications for testing purpose.