### PR TITLE
Adding imagescan example from Xavi

### DIFF
--- a/imagescans/deployment.yaml
+++ b/imagescans/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: 0xavi0/nginx-git:0.0.0-40 # {"$imagescan": "test-scan"}
+        ports:
+        - containerPort: 80

--- a/imagescans/fleet.yaml
+++ b/imagescans/fleet.yaml
@@ -1,0 +1,19 @@
+imageScans:
+# specify the policy to retrieve images, can be semver or alphabetical order
+- policy:
+    # if range is specified, it will take the latest image according to semver order in the range
+    # for more details on how to use semver, see https://github.com/Masterminds/semver
+    semver:
+      range: "*"
+    # can use ascending or descending order
+    alphabetical:
+      order: asc
+
+  # specify images to scan
+  image: "0xavi0/nginx-git"
+
+  # Specify the tag name, it has to be unique in the same bundle
+  tagName: test-scan
+
+  # Specify the scan interval
+  interval: 30s


### PR DESCRIPTION
Adding imagescan example with semver range "*" made by @0xavi0 [here](https://github.com/0xavi0/fleet-examples/blob/test-imagescans/imagescans/fleet.yaml) to test fleet controller is not broken and image is not updated.
