### PR TITLE
Explicitly set deployment spec to its default value

### DIFF
--- a/drift-ignore-status/deployment.yaml
+++ b/drift-ignore-status/deployment.yaml
@@ -1,0 +1,28 @@
+# This deployment is meant to represent the bug at https://github.com/rancher/fleet/issues/2521
+# It includes:
+# - A spec field "paused" set to its default value
+# - A non-empty "status", despite being a subresource and not modifiable by apply
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+  paused: false
+status:
+  collisionCount: 0

--- a/drift-ignore-status/fleet.yaml
+++ b/drift-ignore-status/fleet.yaml
@@ -1,0 +1,1 @@
+namespace: drift-ignore-status


### PR DESCRIPTION
This makes the diff plan generated by [`apply.DryRun`](https://github.com/rancher/fleet/blob/affc5757bc06058de565f9788b42c59ff127395e/internal/cmd/agent/deployer/monitor/updatestatus.go#L158) to include the deployment as modified, since it's present in the spec but omitted from the live object. This causes rancher/fleet#2521 to happen if the object has a `status` field.