### PR TITLE
drift: create new case for resources with explicit status

### DIFF
--- a/drift-ignore-status/deployment.yaml
+++ b/drift-ignore-status/deployment.yaml
@@ -1,0 +1,28 @@
+# This deployment is meant to represent the bug at https://github.com/rancher/fleet/issues/2521
+# It includes:
+# - A spec field "paused" set to its default value
+# - A non-empty "status", despite being a subresource and not modifiable by apply
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+  paused: false
+status:
+  collisionCount: 0

--- a/drift-ignore-status/fleet.yaml
+++ b/drift-ignore-status/fleet.yaml
@@ -1,0 +1,1 @@
+namespace: drift-ignore-status


### PR DESCRIPTION
This config resource triggers a special corner case described at https://github.com/rancher/fleet/issues/2521

There are 2 conditions to reproduce the problem:
1. The object spec must include an explicit field set to its default value, e.g. a deploment's `spec.paused=false` , or a crd's `spec.preserveUnknownFields=false` (the latter is more common, but it will depend on each chart being installed, so everything is possible).
2. The resource manifest contains a non-empty `status` field (regardless of being a subresource, so not really populated by apply).

If that happens, fields within `status` may appear when calculating the three-way strategic merge patch which is used to report the modified status.

Complementary to https://github.com/rancher/fleet/pull/2522
