### PR TITLE
Use lightweight pause image for drift tests

### DIFF
--- a/drift-ignore-status/deployment.yaml
+++ b/drift-ignore-status/deployment.yaml
@@ -19,8 +19,8 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
+      - name: pause
+        image: k8s.gcr.io/pause
         ports:
         - containerPort: 80
   paused: false

--- a/drift-ignore-status/deployment.yaml
+++ b/drift-ignore-status/deployment.yaml
@@ -5,18 +5,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: drift-dummy-deployment
   labels:
-    app: nginx
+    app: drift-dummy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx
+      app: drift-dummy
   template:
     metadata:
       labels:
-        app: nginx
+        app: drift-dummy
     spec:
       containers:
       - name: pause

--- a/drift/deployment.yaml
+++ b/drift/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
+      - name: pause
+        image: k8s.gcr.io/pause
         ports:
         - containerPort: 80

--- a/drift/deployment.yaml
+++ b/drift/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: drift-dummy-deployment
   labels:
-    app: nginx
+    app: drift-dummy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx
+      app: drift-dummy
   template:
     metadata:
       labels:
-        app: nginx
+        app: drift-dummy
     spec:
       containers:
       - name: pause

--- a/drift/svc.yaml
+++ b/drift/svc.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-service
+  name: drift-dummy-service
   labels:
     foo: changed
 spec:
   selector:
     app.kubernetes.io/name: proxy
-  externalName: nginx
+  externalName: drift-dummy
   ports:
   - name: http
     protocol: TCP


### PR DESCRIPTION
This makes use of image `k8s.gcr.io/pause` instead of `nginx`, which should make for shorter deployment times and use less resources. In turn, this reduces flakiness of drift end-to-end tests.

Tested through https://github.com/rancher/fleet/pull/2692.

Note: merging this will break drift end-to-end tests on Fleet's `release/v0.9` branch, until a backport of https://github.com/rancher/fleet/pull/2692 is merged.