### PR TITLE
Delete values from oci chart as they are not required

### DIFF
--- a/simple-chart-oci/fleet.yaml
+++ b/simple-chart-oci/fleet.yaml
@@ -1,4 +1,3 @@
 helm:
   chart: config-chart
-  values:
-    name: example-value-oci-test
+


### PR DESCRIPTION
We need to delete the helm values from this particular case, becase a test fails due to the secret created to store the helm values.
https://github.com/rancher/fleet/actions/runs/15318291692/job/43096265930

Those values are not strictly required for testing the actual OCI storage e2e tests 