### PR TITLE
Add `longhorn-crd` fleet.yaml file to write test

### DIFF
--- a/qa-test-apps/longhorn-crd/README.md
+++ b/qa-test-apps/longhorn-crd/README.md
@@ -1,0 +1,22 @@
+# In this example, we are checking after installation of longhorn-crd,
+# bundle is not in `Modified` state instead it is in `Active` state.
+# See issue for more details: https://github.com/rancher/fleet/issues/2521
+
+This example will deploy the `longhorn CRD's`.
+See [Target Matching](https://fleet.rancher.io/gitrepo-targets#target-matching)
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: test-longhorn-crd-gitrepo-status
+  namespace: fleet-default
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/longhorn-crd
+  targets:
+    - clusterSelector: {}
+```
+

--- a/qa-test-apps/longhorn-crd/fleet.yaml
+++ b/qa-test-apps/longhorn-crd/fleet.yaml
@@ -1,0 +1,6 @@
+defaultNamespace: longhorn-system
+helm:
+  chart: longhorn-crd
+  repo: https://charts.rancher.io
+  releaseName: longhorn-crd
+  version: "103.3.1+up1.6.2"


### PR DESCRIPTION
QA's test automation is using `fleet-test-data` as source of test data to validate Fleet's fixed bugs or enhancements.
In order to write automation for: https://github.com/rancher/fleet/issues/2521 issue, I require `longhorn-crd` data in fleet.yaml 

In this PR:
- We have `fleet.yaml` file containing `longhorn-crd` installation via `helm`.
- `README` file containing usage of it.