### PR TITLE
Add test data for Helm OCI registries via repo and chart field

### DIFF
--- a/qa-test-apps/helm-oci-tests/README.md
+++ b/qa-test-apps/helm-oci-tests/README.md
@@ -1,0 +1,19 @@
+## Helm App examples
+
+Below table illustrates `oci://` repo used via `chart` and `repo` fields in `fleet.yaml` file.
+
+qa-test-apps/helm-oci-tests
+├── chart-oci-url
+│   ├── fleet.yaml
+│   └── README.md
+├── README.md
+└── repo-oci-url
+    ├── fleet.yaml
+    └── README.md
+
+| Example | Description |
+| ------------- | ------------ |
+| [repo-oci-url](qa-test-apps/helm-oci-tests/repo-oci-url) | An example using Helm with `oci://` URL format in the `repo` field of the `fleet.yaml` file |
+| [chart-oci-url](qa-test-apps/helm-oci-tests/chart-oci-url) | An example using Helm with `oci://` URL format in the `chart` field of the `fleet.yaml` file |
+
+_Note: README is present for each examples in respective folders.

--- a/qa-test-apps/helm-oci-tests/chart-oci-url/README.md
+++ b/qa-test-apps/helm-oci-tests/chart-oci-url/README.md
@@ -1,0 +1,16 @@
+### In this example, we are testing if Helm charts can be pulled from OCI registries using the `oci://` URL format in the `chart` field of the `fleet.yaml` file.
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: test-helm-oci-chart-url
+  namespace: fleet-default
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/helm-oci-tests/chart-oci-url
+  targets:
+    - clusterSelector: {}
+```

--- a/qa-test-apps/helm-oci-tests/chart-oci-url/fleet.yaml
+++ b/qa-test-apps/helm-oci-tests/chart-oci-url/fleet.yaml
@@ -1,0 +1,9 @@
+namespace: fleet-helm-chart-oci-example
+helm:
+  releaseName: fleet-test-configmap
+  chart: "oci://ghcr.io/rancher/fleet-test-configmap-chart"
+  version: "0.1.0"
+  force: false
+  timeoutSeconds: 0
+  values:
+    replicas: 2

--- a/qa-test-apps/helm-oci-tests/repo-oci-url/README.md
+++ b/qa-test-apps/helm-oci-tests/repo-oci-url/README.md
@@ -1,0 +1,16 @@
+### In this example, we are testing if Helm charts can be pulled from OCI registries using the `oci://` URL format in the `repo` field of the `fleet.yaml` file.
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: test-helm-oci-repo-url
+  namespace: fleet-default
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/helm-oci-tests/repo-oci-url
+  targets:
+    - clusterSelector: {}
+```

--- a/qa-test-apps/helm-oci-tests/repo-oci-url/fleet.yaml
+++ b/qa-test-apps/helm-oci-tests/repo-oci-url/fleet.yaml
@@ -1,0 +1,11 @@
+namespace: fleet-helm-repo-oci-example
+
+# Custom helm options
+helm:
+  releaseName: fleet-test-configmap
+  repo: "oci://ghcr.io/rancher/fleet-test-configmap-chart"
+  version: "0.1.0"
+  force: false
+  timeoutSeconds: 0
+  values:
+    replicas: 2


### PR DESCRIPTION
QA Test data for automate tests related to OCI registry URL usage in `fleet.yaml` fields: `helm.chart` and `helm.repo`.
