### PR TITLE
Add nginx deployment with delayed readiness probe to check GitRepo notReady state

### DIFF
--- a/qa-test-apps/nginx-app-with-delayed-readiness/README.md
+++ b/qa-test-apps/nginx-app-with-delayed-readiness/README.md
@@ -1,0 +1,17 @@
+# In this example, we will deploy the `nginx` application with delayed readiness. The app will be deployed to all available clusters in the `nginx-delayed-readiness` namespace
+
+## This nginx-delayed-readiness deployment is used to check the GitRepo's `notReady` state
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: test-gitrepo-not-ready-state
+spec:
+  repo: https://github.com/rancher/fleet-test-data/
+  branch: master
+  paths:
+  - qa-test-apps/nginx-app-with-delayed-readiness
+  targets:
+    - clusterSelector: {}
+```

--- a/qa-test-apps/nginx-app-with-delayed-readiness/fleet.yaml
+++ b/qa-test-apps/nginx-app-with-delayed-readiness/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: nginx-delayed-readiness

--- a/qa-test-apps/nginx-app-with-delayed-readiness/nginx.yaml
+++ b/qa-test-apps/nginx-app-with-delayed-readiness/nginx.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-delayed-readiness
+  namespace: nginx-delayed-readiness
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-delayed-readiness
+  template:
+    metadata:
+      labels:
+        app: nginx-delayed-readiness
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 30    # Long delay to catch notReady state
+          periodSeconds: 10
+          failureThreshold: 3
+        startupProbe:                 # Optional: ensures even longer startup
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          failureThreshold: 6         # 6 attempts = 30 seconds


### PR DESCRIPTION
### Requirement
- In order to write automation for GitRepo states mentioned under `perClusterResourceCounts:` 
  - For `notReady` state we require application which will take some time to start or become active.

### Solution
- In this PR, `nginx-delayed-readiness` deployment will take significant amount of time to start.
- During the startup phase, GitRepo will be in `NotReady` state. (Yess, this is what we want for validation).