### PR TITLE
Test data for namespace labels and annotations configuration files

### DIFF
--- a/qa-test-apps/namespace-labels-annotations/README.md
+++ b/qa-test-apps/namespace-labels-annotations/README.md
@@ -1,0 +1,16 @@
+# Namespace Labels and Annotations
+
+The following tree structure illustrates how `namespaceLabels` and `namespaceAnnotations` in `fleet.yaml` are applied to the namespace Fleet creates for a bundle (Fleet [issue #1553](https://github.com/rancher/fleet/issues/1553)).
+
+- `fleet.yaml` sets `defaultNamespace: my-labeled-namespace` and configures `namespaceLabels` (`env: test`) and `namespaceAnnotations` (`pod: deny`).
+- When the bundle is deployed, Fleet creates `my-labeled-namespace` with those labels and annotations applied to it.
+
+    ```text
+    qa-test-apps/namespace-labels-annotations
+    ├── README.md
+    ├── configmap.yaml
+    └── fleet.yaml
+    ```
+
+> [!NOTE]
+> `namespaceLabels` and `namespaceAnnotations` apply only to the namespace that Fleet creates (the `defaultNamespace` / `targetNamespace`). They are not applied to namespaces defined as resources inside the bundle. This is commonly used to add Pod Security Admission labels to bundle namespaces.

--- a/qa-test-apps/namespace-labels-annotations/configmap.yaml
+++ b/qa-test-apps/namespace-labels-annotations/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: namespace-labels-config
+data:
+  name: "ConfigMap for namespace labels and annotations test."

--- a/qa-test-apps/namespace-labels-annotations/fleet.yaml
+++ b/qa-test-apps/namespace-labels-annotations/fleet.yaml
@@ -1,0 +1,5 @@
+defaultNamespace: my-labeled-namespace
+namespaceLabels:
+  env: test
+namespaceAnnotations:
+  pod: deny


### PR DESCRIPTION
## Add `namespace-labels-annotations` test app for Fleet issue #1553

Adds a minimal bundle that exercises `namespaceLabels` and `namespaceAnnotations` in `fleet.yaml` file.

### What will be added

- `qa-test-apps/namespace-labels-annotations/fleet.yaml` — sets `defaultNamespace: my-labeled-namespace` with `namespaceLabels` (`env: test`) and `namespaceAnnotations` (`pod: deny`).
- `qa-test-apps/namespace-labels-annotations/configmap.yaml` — trivial ConfigMap so the bundle has a deployable resource.
- `qa-test-apps/namespace-labels-annotations/README.md` — tree layout + note that these fields apply only to the namespace Fleet creates (the `defaultNamespace` / `targetNamespace`), a common use for Pod Security Admission labels.
