### PR TITLE
Add test data for helm resource policy configurations and related resources

### DIFF
--- a/qa-test-apps/helm-resource-policy/README.md
+++ b/qa-test-apps/helm-resource-policy/README.md
@@ -22,17 +22,23 @@
 See issue for more details: https://github.com/rancher/fleet/issues/2716
 
 > [!IMPORTANT]
-> The `Service` is what makes this bundle useful — do not "simplify" it away.
-> The bug leaked `helm.sh/resource-policy: keep` onto every resource processed
-> *after* the first CRD. Helm sorts manifests by install order before Fleet's
-> post-renderer runs, and `CustomResourceDefinition` sorts **after** `ConfigMap`
-> but **before** `Service`. A bundle of CRD + ConfigMap alone would therefore
-> pass even on an affected build. The `ConfigMap` is kept deliberately as the
-> other side of that boundary.
+> `default` is the regression check; do not "simplify" the `Service` away.
+> The bug leaked the annotation onto every resource processed *after* the first
+> CRD. Fleet packages these plain YAML files into a Helm chart, and Helm sorts
+> the manifests **by kind** before Fleet's post-renderer sees them:
+> `ConfigMap` → `CustomResourceDefinition` → `Service`. So the `Service` is the
+> resource that used to inherit the annotation and the `ConfigMap` is the control
+> on the other side. Renaming the files is harmless, but replacing the `Service`
+> with an early-sorting kind such as `Secret` or `ServiceAccount` would silently
+> stop this bundle from catching the regression.
 
 > [!NOTE]
-> Each directory declares a different CRD name and `defaultNamespace`. Under
-> `default` the CRD outlives its `GitRepo` by design — that is what `keep` means —
-> so sharing a name across the two bundles would break Helm release ownership.
-> Remove it explicitly with
-> `kubectl delete crd resourcepolicykeeps.qa.fleet.cattle.io` when cleaning up.
+> `delete-crd-resources` covers the flag's behaviour, not the bug — with
+> `deleteCRDResources: true` the affected code path never runs, so the result is
+> the same before and after the fix.
+
+> [!NOTE]
+> Each directory uses a different CRD name and `defaultNamespace`. Under `default`
+> the CRD outlives its `GitRepo` by design — that is what `keep` means — so a
+> shared name would break Helm release ownership. Clean up with
+> `kubectl delete crd resourcepolicykeeps.qa.fleet.cattle.io`.

--- a/qa-test-apps/helm-resource-policy/README.md
+++ b/qa-test-apps/helm-resource-policy/README.md
@@ -1,0 +1,38 @@
+# The following tree structure illustrates how `deleteCRDResources` in `fleet.yaml` controls the `helm.sh/resource-policy: keep` annotation
+
+- `deleteCRDResources` unset (defaults to `false`) — Fleet annotates **only the CRDs** with `helm.sh/resource-policy: keep`.
+
+- `deleteCRDResources: true` — Fleet annotates **nothing**; the CRDs are removed along with the rest of the bundle.
+
+    ```yaml
+    qa-test-apps/helm-resource-policy
+    ├── default
+    │   ├── configmap.yaml
+    │   ├── crd.yaml
+    │   ├── fleet.yaml
+    │   └── service.yaml
+    ├── delete-crd-resources
+    │   ├── configmap.yaml
+    │   ├── crd.yaml
+    │   ├── fleet.yaml
+    │   └── service.yaml
+    └── README.md
+    ```
+
+See issue for more details: https://github.com/rancher/fleet/issues/2716
+
+> [!IMPORTANT]
+> The `Service` is what makes this bundle useful — do not "simplify" it away.
+> The bug leaked `helm.sh/resource-policy: keep` onto every resource processed
+> *after* the first CRD. Helm sorts manifests by install order before Fleet's
+> post-renderer runs, and `CustomResourceDefinition` sorts **after** `ConfigMap`
+> but **before** `Service`. A bundle of CRD + ConfigMap alone would therefore
+> pass even on an affected build. The `ConfigMap` is kept deliberately as the
+> other side of that boundary.
+
+> [!NOTE]
+> Each directory declares a different CRD name and `defaultNamespace`. Under
+> `default` the CRD outlives its `GitRepo` by design — that is what `keep` means —
+> so sharing a name across the two bundles would break Helm release ownership.
+> Remove it explicitly with
+> `kubectl delete crd resourcepolicykeeps.qa.fleet.cattle.io` when cleaning up.

--- a/qa-test-apps/helm-resource-policy/default/configmap.yaml
+++ b/qa-test-apps/helm-resource-policy/default/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-policy-cm
+data:
+  # Helm renders ConfigMaps *before* CRDs, so this resource was never affected
+  # by the bug. It is here as a control.
+  note: rendered-before-the-crd

--- a/qa-test-apps/helm-resource-policy/default/crd.yaml
+++ b/qa-test-apps/helm-resource-policy/default/crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcepolicykeeps.qa.fleet.cattle.io
+spec:
+  group: qa.fleet.cattle.io
+  scope: Namespaced
+  names:
+    kind: ResourcePolicyKeep
+    listKind: ResourcePolicyKeepList
+    plural: resourcepolicykeeps
+    singular: resourcepolicykeep
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object

--- a/qa-test-apps/helm-resource-policy/default/fleet.yaml
+++ b/qa-test-apps/helm-resource-policy/default/fleet.yaml
@@ -1,0 +1,4 @@
+defaultNamespace: helm-resource-policy-keep
+
+# deleteCRDResources is intentionally left unset here; it defaults to false,
+# which is the case where Fleet annotates CRDs with "helm.sh/resource-policy: keep".

--- a/qa-test-apps/helm-resource-policy/default/service.yaml
+++ b/qa-test-apps/helm-resource-policy/default/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Helm renders Services *after* CRDs, so this is the resource that used to
+  # inherit "helm.sh/resource-policy: keep". Do not remove it.
+  name: resource-policy-svc
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/qa-test-apps/helm-resource-policy/delete-crd-resources/configmap.yaml
+++ b/qa-test-apps/helm-resource-policy/delete-crd-resources/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-policy-cm
+data:
+  # Helm renders ConfigMaps *before* CRDs, so this resource was never affected
+  # by the bug. It is here as a control.
+  note: rendered-before-the-crd

--- a/qa-test-apps/helm-resource-policy/delete-crd-resources/crd.yaml
+++ b/qa-test-apps/helm-resource-policy/delete-crd-resources/crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # A different name from the one in ../default so the two bundles never collide:
+  # the CRD deployed by ../default outlives its GitRepo because of the "keep" policy.
+  name: resourcepolicydeletes.qa.fleet.cattle.io
+spec:
+  group: qa.fleet.cattle.io
+  scope: Namespaced
+  names:
+    kind: ResourcePolicyDelete
+    listKind: ResourcePolicyDeleteList
+    plural: resourcepolicydeletes
+    singular: resourcepolicydelete
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object

--- a/qa-test-apps/helm-resource-policy/delete-crd-resources/fleet.yaml
+++ b/qa-test-apps/helm-resource-policy/delete-crd-resources/fleet.yaml
@@ -1,0 +1,5 @@
+defaultNamespace: helm-resource-policy-delete
+
+# With deleteCRDResources enabled Fleet does not add "helm.sh/resource-policy: keep"
+# to CRDs at all, so no resource in this bundle should carry the annotation.
+deleteCRDResources: true

--- a/qa-test-apps/helm-resource-policy/delete-crd-resources/service.yaml
+++ b/qa-test-apps/helm-resource-policy/delete-crd-resources/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Helm renders Services *after* CRDs, so this is the resource that used to
+  # inherit "helm.sh/resource-policy: keep". Do not remove it.
+  name: resource-policy-svc
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Add `qa-test-apps/helm-resource-policy` test data

Test data for [rancher/fleet#2716](https://github.com/rancher/fleet/issues/2716) — `helm.sh/resource-policy: keep` was being added to every resource instead of just CRDs.


Each variant deploys a dummy CRD, a selector-less ClusterIP `Service` and a `ConfigMap` — no external Helm repo, no pods, deploys in seconds.

| Directory | `deleteCRDResources` | Annotation on CRD | Annotation on Service / ConfigMap |
|---|---|---|---|
| `default/` | unset (`false`) | **present** | **never** |
| `delete-crd-resources/` | `true` | **absent** | **never** |

**Why a `Service` and not just a `ConfigMap`.** Helm sorts manifests by install order before Fleet's post-renderer runs, and `CustomResourceDefinition` sorts after `ConfigMap` but before `Service`. The bug only leaked onto resources processed *after* the first CRD, so a CRD + ConfigMap bundle would pass even on an affected build. The `Service` is the real regression check; the `ConfigMap` is the control. Flagged in the README so it doesn't get "simplified" away.

**Cleanup.** The two directories use different CRD names and namespaces on purpose — under `default/` the CRD outlives its `GitRepo` (that's what `keep` means), so a shared name would break Helm release ownership. Remove it with `kubectl delete crd resourcepolicykeeps.qa.fleet.cattle.io`.
